### PR TITLE
Cleanup minor changes for HybridGlobalization

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -334,7 +334,6 @@ jobs:
         dotnetVersionsLinks:
           main: https://aka.ms/dotnet/sdk/maui/net8.0.json
         runtimeFlavor: mono
-        hybridGlobalization: false
 
   - template: /eng/performance/build_machine_matrix.yml
     parameters:
@@ -349,6 +348,7 @@ jobs:
           main: https://aka.ms/dotnet/sdk/maui/net8.0.json
         runtimeFlavor: mono
         hybridGlobalization: true
+        additionalJobIdentifier: 'HybridGlobalization_True'
 
   # Maui iOS Native AOT scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -363,7 +363,6 @@ jobs:
         dotnetVersionsLinks:
           main: https://aka.ms/dotnet/sdk/maui/net8.0.json
         runtimeFlavor: coreclr
-        hybridGlobalization: false
 
   - template: /eng/performance/build_machine_matrix.yml
     parameters:
@@ -378,6 +377,7 @@ jobs:
           main: https://aka.ms/dotnet/sdk/maui/net8.0.json
         runtimeFlavor: coreclr
         hybridGlobalization: true
+        additionalJobIdentifier: 'HybridGlobalization_True'
 
   ## Maui scenario benchmarks
   #- template: /eng/performance/build_machine_matrix.yml

--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -11,8 +11,13 @@
     <PreparePayloadOutDirectoryName>scenarios_out</PreparePayloadOutDirectoryName>
     <PreparePayloadWorkItemBaseDirectory Condition="'$(TargetsWindows)' == 'true'">$(CorrelationPayloadDirectory)$(PreparePayloadOutDirectoryName)\</PreparePayloadWorkItemBaseDirectory>
     <PreparePayloadWorkItemBaseDirectory Condition="'$(TargetsWindows)' != 'true'">$(CorrelationPayloadDirectory)$(PreparePayloadOutDirectoryName)/</PreparePayloadWorkItemBaseDirectory>
+    
     <NativeAOTCommandProps Condition="'$(RuntimeFlavor)' == 'coreclr'">--nativeaot true</NativeAOTCommandProps>
-    <HybridGlobalizationCommandProps Condition="'$(HybridGlobalization)' == 'true'">--hybrid-globalization true</HybridGlobalizationCommandProps>
+    <!-- For non-default configurations, add the configuration to the name of the test (in the matching format), otherwise didn't add anything.
+    This will ensure that PowerBI's using the test name rather than the run configuration for the data continue to work properly and defaults are connected -->
+    <HybridGlobalizationString></HybridGlobalizationString>
+    <HybridGlobalizationString Condition="'$(HybridGlobalization)' == 'true'"> HybridGlobalization</HybridGlobalizationString>
+    <RunConfigsString>$(RuntimeFlavor)$(HybridGlobalizationString)</RunConfigsString>
   </PropertyGroup>
 
   <Target Name="RemoveDotnetFromCorrelationStaging" BeforeTargets="BeforeTest">
@@ -27,19 +32,19 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <MAUIiOSScenario Include="Xamarin iOS Default $(RuntimeFlavor) HybridGlobalization $(HybridGlobalization)">
+    <MAUIiOSScenario Include="Xamarin iOS Default $(RunConfigsString)">
       <ScenarioDirectoryName>xamarinios</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <IPAName>XamariniOSDefault</IPAName>
       <PackageName>com.companyname.XamariniOSDefault</PackageName>
     </MAUIiOSScenario>
-    <MAUIiOSScenario Include="Maui iOS Default $(RuntimeFlavor) HybridGlobalization $(HybridGlobalization)">
+    <MAUIiOSScenario Include="Maui iOS Default $(RunConfigsString)">
       <ScenarioDirectoryName>mauiios</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <IPAName>MauiiOSDefault</IPAName>
       <PackageName>net.dot.mauitesting</PackageName>
     </MAUIiOSScenario>
-    <MAUIiOSScenario Include="Maui Blazor iOS Default $(RuntimeFlavor) HybridGlobalization $(HybridGlobalization)">
+    <MAUIiOSScenario Include="Maui Blazor iOS Default $(RunConfigsString)">
       <ScenarioDirectoryName>mauiblazorios</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <IPAName>MauiBlazoriOSDefault</IPAName>
@@ -56,7 +61,7 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIiOSScenario)">
-      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 $(NativeAOTCommandProps) $(HybridGlobalizationCommandProps) -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 $(NativeAOTCommandProps) --hybrid-globalization $(HybridGlobalization) -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>
@@ -70,7 +75,7 @@
       <PreCommands>cp -r $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName) $HELIX_WORKITEM_ROOT/pub; mv $HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).ipa $HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).zip; unzip -d $HELIX_WORKITEM_ROOT/pub $HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).zip; rm $HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).zip</PreCommands>
       <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
     </HelixWorkItem>
-    <XHarnessAppBundleToTest Include="Device Startup - iOS Xamarin Default $(RuntimeFlavor) HybridGlobalization $(HybridGlobalization)">
+    <XHarnessAppBundleToTest Include="Device Startup - iOS Xamarin Default $(RunConfigsString)">
       <AppBundlePath>$(ScenariosDir)xamarinios.zip</AppBundlePath>
       <WorkItemTimeout>00:15:00</WorkItemTimeout>
       <TestTarget>ios-device</TestTarget>
@@ -98,7 +103,7 @@
           ]]>
         </CustomCommands>
     </XHarnessAppBundleToTest>
-    <XHarnessAppBundleToTest Include="Device Startup - iOS Maui Default $(RuntimeFlavor) HybridGlobalization $(HybridGlobalization)">
+    <XHarnessAppBundleToTest Include="Device Startup - iOS Maui Default $(RunConfigsString)">
       <AppBundlePath>$(ScenariosDir)mauiios.zip</AppBundlePath>
       <WorkItemTimeout>00:15:00</WorkItemTimeout>
       <TestTarget>ios-device</TestTarget>
@@ -126,7 +131,7 @@
           ]]>
         </CustomCommands>
     </XHarnessAppBundleToTest>
-    <XHarnessAppBundleToTest Include="Device Startup - iOS Maui Blazor Default $(RuntimeFlavor) HybridGlobalization $(HybridGlobalization)">
+    <XHarnessAppBundleToTest Include="Device Startup - iOS Maui Blazor Default $(RunConfigsString)">
       <AppBundlePath>$(ScenariosDir)mauiblazorios.zip</AppBundlePath>
       <WorkItemTimeout>00:15:00</WorkItemTimeout>
       <TestTarget>ios-device</TestTarget>

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -23,8 +23,8 @@ jobs:
     enablePublishBuildArtifacts: true
     helixRepo: dotnet/performance
     jobs:
-      - job: '${{ parameters.osName }}_${{ parameters.osVersion }}_${{ parameters.architecture }}_${{ parameters.kind }}_${{ parameters.runtimeFlavor }}_hybridGlobalization_${{ parameters.hybridGlobalization }}_${{ parameters.machinePool }}${{ parameters.additionalJobIdentifier }}'
-        displayName: '${{ parameters.osName }} ${{ parameters.osVersion }} ${{ parameters.architecture }} ${{ parameters.kind }} ${{ parameters.runtimeFlavor }} HybridGlobalization ${{ parameters.hybridGlobalization }} ${{ parameters.machinePool }} ${{ parameters.additionalJobIdentifier }}'
+      - job: '${{ parameters.osName }}_${{ parameters.osVersion }}_${{ parameters.architecture }}_${{ parameters.kind }}_${{ parameters.runtimeFlavor }}_${{ parameters.machinePool }}${{ parameters.additionalJobIdentifier }}'
+        displayName: '${{ parameters.osName }} ${{ parameters.osVersion }} ${{ parameters.architecture }} ${{ parameters.kind }} ${{ parameters.runtimeFlavor }} ${{ parameters.machinePool }} ${{ parameters.additionalJobIdentifier }}'
         timeoutInMinutes: 320
         variables:
         - name: AffinityValue # Make the affinity value available to the csproj generation
@@ -33,6 +33,11 @@ jobs:
           ${{ if ne(parameters.affinity, '0')}}:
             value: '--affinity ${{ parameters.affinity }}'
           ${{ else }}: # Affinity of 0 seems to cause problems with BDN, so don't set it if we don't need to
+            value: ''
+        - name: HybridGlobalizationConfig
+          ${{ if eq(parameters.hybridGlobalization, 'true')}}:
+            value: ' HybridGlobalization=True'
+          ${{ else }}: # Only include hybridGlobalization if explicitly set to true
             value: ''
         - name: runEnvVarsParam
           ${{ if ne(length(parameters.runEnvVars), 0)}}:
@@ -118,7 +123,7 @@ jobs:
         - checkout: self
           clean: true
         - ${{ if ne(length(parameters.channels), 0) }}:
-          - script: $(Python) scripts/ci_setup.py --channel $(_Channel) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs) --output-file $(CorrelationStaging)machine-setup --install-dir $(CorrelationStaging)dotnet $(runEnvVarsParam) $(AffinityParam) $(TargetsWindowsParam)
+          - script: $(Python) scripts/ci_setup.py --channel $(_Channel) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs)$(HybridGlobalizationConfig) --output-file $(CorrelationStaging)machine-setup --install-dir $(CorrelationStaging)dotnet $(runEnvVarsParam) $(AffinityParam) $(TargetsWindowsParam)
             displayName: Run ci_setup.py
         - ${{ elseif ne(length(parameters.dotnetVersionsLinks), 0) }}:
           - powershell: |
@@ -130,7 +135,7 @@ jobs:
               Write-Host "##vso[task.setvariable variable=DotnetVersion;]$dotnet_version"
               Write-Host "Found dotnet version $dotnet_version"
             displayName: Get dotnetVersion to use
-          - script: $(Python) scripts/ci_setup.py --channel $(_Channel) --dotnet-versions $(DotnetVersion) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs) --output-file $(CorrelationStaging)machine-setup --install-dir $(CorrelationStaging)dotnet $(runEnvVarsParam) $(AffinityParam) $(TargetsWindowsParam)
+          - script: $(Python) scripts/ci_setup.py --channel $(_Channel) --dotnet-versions $(DotnetVersion) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber)$(HybridGlobalizationConfig) --build-configs $(_Configs) --output-file $(CorrelationStaging)machine-setup --install-dir $(CorrelationStaging)dotnet $(runEnvVarsParam) $(AffinityParam) $(TargetsWindowsParam)
             displayName: Run ci_setup.py with dotnetVersionsLinks
         - powershell: |
             Write-Host "##vso[task.setvariable variable=DOTNET_ROOT;]$(CorrelationStaging)dotnet"


### PR DESCRIPTION
Multiple changes: In azure-pipelines.yml, remove false hybridglobalization as it is the default and use additionalJobIdentifier instead of adding hybridglobalization to all the jobs. In maui_scenarios_ios.proj, make it so HybridGlobalization only shows up in the HG true run titles and switch to using a RunConfigString that includes all runconfigs where they are created for easy addition of configs to all scenarios. In scnearios.yml, add HybridGlobalization as a build config when true and remove it from the job name (switched to using additionalJobIdentifier).



